### PR TITLE
Update NSimpleEventStore

### DIFF
--- a/src/nsimplemessagepump/nsimplemessagepump.contract/MessagePumpFluentRegistration.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.contract/MessagePumpFluentRegistration.cs
@@ -1,5 +1,5 @@
 using System;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;

--- a/src/nsimplemessagepump/nsimplemessagepump.contract/messagecontext/IMessageContextModelBuilder.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.contract/messagecontext/IMessageContextModelBuilder.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 
 namespace nsimplemessagepump.contract.messagecontext
 {

--- a/src/nsimplemessagepump/nsimplemessagepump.contract/messageprocessing/ICommandProcessor.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.contract/messageprocessing/ICommandProcessor.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract.messagecontext;
 
 namespace nsimplemessagepump.contract.messageprocessing

--- a/src/nsimplemessagepump/nsimplemessagepump.contract/nsimplemessagepump.contract.csproj
+++ b/src/nsimplemessagepump/nsimplemessagepump.contract/nsimplemessagepump.contract.csproj
@@ -5,13 +5,13 @@
 
         <PackageId>NSimpleMessagePump.Contract</PackageId>
         <Description>Contract for NSimpleMessagePump</Description>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <Authors>Ralf Westphal</Authors>
         <Company>One Man Think Tank, Hamburg</Company>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="NSimpleEventStore.Contract" Version="1.0.2" />
+      <PackageReference Include="NSimpleEventStore.Contract" Version="2.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/CommandPipeline_tests.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/CommandPipeline_tests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.pipeline;

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/EventBroadcast_tests.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/EventBroadcast_tests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using Xunit;
 
 namespace nsimplemessagepump.tests

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/Notificationpipeline_tests.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/Notificationpipeline_tests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/nsimplemessagepump.tests.csproj
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/nsimplemessagepump.tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="NSimpleEventStore" Version="2.2.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     </ItemGroup>

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/events/TodoChecked.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/events/TodoChecked.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 
 namespace nsimplemessagepump.tests.usecase.events
 {

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/events/TodoCreated.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/events/TodoCreated.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 
 namespace nsimplemessagepump.tests.usecase.events
 {

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/AddTodoCmdCtxModelManager.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/AddTodoCmdCtxModelManager.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/AddTodoCmdProcessor.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/AddTodoCmdProcessor.cs
@@ -1,4 +1,4 @@
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/CheckTodoCmdCtxModelManager.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/CheckTodoCmdCtxModelManager.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.tests.usecase.events;

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/CheckTodoCmdProcessor.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/commands/CheckTodoCmdProcessor.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;

--- a/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/queries/AllTodosQueryCtxModelManager.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump.tests/usecase/pipelines/queries/AllTodosQueryCtxModelManager.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.tests.usecase.events;

--- a/src/nsimplemessagepump/nsimplemessagepump/MessagePump.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump/MessagePump.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;

--- a/src/nsimplemessagepump/nsimplemessagepump/nsimplemessagepump.csproj
+++ b/src/nsimplemessagepump/nsimplemessagepump/nsimplemessagepump.csproj
@@ -5,14 +5,13 @@
 
         <PackageId>NSimpleMessagePump</PackageId>
         <Description>A very simple framework to try out the Event-Orientation paradigm</Description>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <Authors>Ralf Westphal</Authors>
         <Company>One Man Think Tank, Hamburg</Company>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="NSimpleEventStore" Version="1.0.2" />
-      <PackageReference Include="NSimpleMessagePump.Contract" Version="1.1.0" />
+      <PackageReference Include="NSimpleMessagePump.Contract" Version="1.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/nsimplemessagepump/nsimplemessagepump/pipeline/CommandPipeline.cs
+++ b/src/nsimplemessagepump/nsimplemessagepump/pipeline/CommandPipeline.cs
@@ -1,5 +1,5 @@
 using System;
-using nsimpleeventstore;
+using nsimpleeventstore.contract;
 using nsimplemessagepump.contract;
 using nsimplemessagepump.contract.messagecontext;
 using nsimplemessagepump.contract.messageprocessing;


### PR DESCRIPTION
I've updated the NSimpleEventStore to the latest version. See https://github.com/ralfw/NSimpleEventstore/pull/7.

With this update we enable support for JsonSerializer settings.

I've also set a new version for both projects. Please keep in mind, that we aren't able to compile the project because of its reference structure. You're using NuGet references within the solution. Because I don't know how you release such projects, but this way you have to release the contracts first and then you're able to compile again.